### PR TITLE
refactor: API 응답 에러코드 개선

### DIFF
--- a/module-common/src/main/java/com/whiskey/exception/AuthErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/AuthErrorCode.java
@@ -1,0 +1,28 @@
+package com.whiskey.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthErrorCode implements BaseErrorCode {
+    // JWT 토큰 관련
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
+
+    // 회원 인증 관련
+    MEMBER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 회원입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
+
+    // 계정 상태
+    ACCOUNT_INACTIVE(HttpStatus.FORBIDDEN, "비활성화된 계정입니다."),
+    ACCOUNT_WITHDRAW(HttpStatus.FORBIDDEN, "탈퇴한 계정입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    AuthErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/module-common/src/main/java/com/whiskey/exception/BaseErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/BaseErrorCode.java
@@ -2,7 +2,7 @@ package com.whiskey.exception;
 
 import org.springframework.http.HttpStatus;
 
-public interface GlobalErrorCode {
+public interface BaseErrorCode {
     HttpStatus getHttpStatus();
     String getMessage();
     String name();

--- a/module-common/src/main/java/com/whiskey/exception/BusinessException.java
+++ b/module-common/src/main/java/com/whiskey/exception/BusinessException.java
@@ -4,22 +4,22 @@ import lombok.Getter;
 
 @Getter
 public class BusinessException extends RuntimeException {
-    private final ErrorCode errorCode;
+    private final BaseErrorCode errorCode;
     private final Object data;
 
-    public BusinessException(ErrorCode errorCode) {
+    public BusinessException(BaseErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
         this.data = null;
     }
 
-    public BusinessException(ErrorCode errorCode, String message) {
+    public BusinessException(BaseErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
         this.data = null;
     }
 
-    public BusinessException(ErrorCode errorCode, String message, Object data) {
+    public BusinessException(BaseErrorCode errorCode, String message, Object data) {
         super(message);
         this.errorCode = errorCode;
         this.data = data;

--- a/module-common/src/main/java/com/whiskey/exception/CommonErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/CommonErrorCode.java
@@ -4,12 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum CommonErrorCode implements GlobalErrorCode {
-    // 인증 관련
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
-
+public enum CommonErrorCode implements BaseErrorCode {
     // 서버 에러
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
 

--- a/module-common/src/main/java/com/whiskey/exception/CommonErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/CommonErrorCode.java
@@ -1,0 +1,23 @@
+package com.whiskey.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommonErrorCode implements GlobalErrorCode {
+    // 인증 관련
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+
+    // 서버 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    CommonErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/module-common/src/main/java/com/whiskey/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/ErrorCode.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@Deprecated
 public enum ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),

--- a/module-common/src/main/java/com/whiskey/exception/GlobalErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/GlobalErrorCode.java
@@ -1,0 +1,9 @@
+package com.whiskey.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface GlobalErrorCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+    String name();
+}

--- a/module-common/src/main/java/com/whiskey/exception/MemberErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/MemberErrorCode.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum MemberErrorCode implements GlobalErrorCode {
+public enum MemberErrorCode implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),

--- a/module-common/src/main/java/com/whiskey/exception/MemberErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package com.whiskey.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberErrorCode implements GlobalErrorCode {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "올바른 이메일 형식이 아닙니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    MemberErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/module-domain/src/main/java/com/whiskey/domain/member/Member.java
+++ b/module-domain/src/main/java/com/whiskey/domain/member/Member.java
@@ -48,4 +48,14 @@ public class Member extends BaseEntity {
         this.email = email;
         this.status = status;
     }
+
+    // 휴면계정 체크
+    public boolean isLocked() {
+        return MemberStatus.INACTIVE.equals(status);
+    }
+
+    // 탈퇴계정 체크
+    public boolean isExpired() {
+        return MemberStatus.WITHDRAW.equals(status);
+    }
 }

--- a/module-domain/src/main/java/com/whiskey/domain/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/com/whiskey/domain/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndStatus(String email, MemberStatus memberStatus);
 
     Optional<Member> findByEmailAndStatus(String email, MemberStatus memberStatus);
+
+    Optional<Member> findByEmail(String email);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#50 

## 📝작업 내용

module-common에 BusinessException이 존재, 하지만 ErrorCode가 에러 타입을 정의하고 예외까지 생성
+ ErrorCode : 에러 타입 정의 + 예외 생성 (역할 2개, BusinessException과 예외 생성 겹침)
+ BusinessException : 예외 생성 (역할 1개)

ErrorCode는 에러 타입 정의에 집중하고 예외 생성은 BusinessException이 집중하도록 개선

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
