### PR TITLE
refactor : 위스키 목록 조회 API에 복합 커서 페이지네이션 적용

### DIFF
--- a/module-api/src/main/java/com/whiskey/whiskey/dto/WhiskeySearchRequest.java
+++ b/module-api/src/main/java/com/whiskey/whiskey/dto/WhiskeySearchRequest.java
@@ -1,6 +1,7 @@
 package com.whiskey.whiskey.dto;
 
 import com.whiskey.domain.whiskey.enums.MaltType;
+import com.whiskey.domain.whiskey.enums.WhiskeySortType;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
@@ -15,9 +16,14 @@ public record WhiskeySearchRequest(
     String description,
     Long cursor,
     @Min(7) @Max(50)
-    Integer size
+    Integer size,
+    WhiskeySortType sortType
 ) {
     public WhiskeySearchRequest {
+        if(size == null || size < 0) {
+            size = 7;
+        }
+
         if(cursor != null && cursor < 0) {
             throw new IllegalArgumentException("cursor는 0보다 커야합니다.");
         }

--- a/module-domain/src/main/java/com/whiskey/domain/whiskey/enums/WhiskeySortType.java
+++ b/module-domain/src/main/java/com/whiskey/domain/whiskey/enums/WhiskeySortType.java
@@ -1,0 +1,14 @@
+package com.whiskey.domain.whiskey.enums;
+
+public enum WhiskeySortType {
+    LATEST("latest", "최신순"),
+    POPULAR("review_count", "리뷰 많은순");
+
+    private final String value;
+    private final String description;
+
+    WhiskeySortType(String value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

위스키 목록 조회 API에 복합 커서 페이지네이션 적용

### 주요 변경사항
- 정렬 옵션 : 최신순(LATEST), 리뷰많은순(POPULAR) 지원
- 복합 커서 구조 적용
- 검색 파라밑 다중 선택 지원(age, abvs, volume 등)

### 의사결정 사항
1. 정렬 옵션 범위
- ✅ 구현: 신상품순, 리뷰많은순
- ⏭️ 제외: 가격순, 할인율순, 평점순

**제외 이유**:
- 가격순: Stocks 테이블 조인 필요, 구조 개선 선행 필요 (Issue #XXX)
- 할인율순: 할인율 컬럼 및 계산 로직 필요, 우선순위 낮음
- 평점순: 리뷰 수 편향 문제(가중 평점 필요), 레퍼런스 앱에도 미존재

**2. 검색 파라미터 구조**
- 단일 값 → List로 변경 (다중 선택 지원)
- 레퍼런스 앱(데일리샷) 동일 방식 적용
- IN 절로 처리, 최대 선택 개수 제한 (@Size)

### 향후 작업
- [ ] Whiskey 테이블에 price 컬럼 이동 (구조 개선)
- [ ] 가격순 정렬 추가 (price 이동 후)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
