### PR TITLE
fix : Toss API 키를 yml 평문에서 .env 로 외부화 (#60)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# 로컬 실행용 환경변수 예시. 복사해서 .env 로 만들고 값을 채운다.
+#   cp .env.example .env
+# .env 는 커밋되지 않는다(.gitignore). 배포(EC2/Docker)는 --env-file 로 동일 변수를 주입한다.
+
+# Toss 결제 API 키 (실운영 아님 — Toss 샌드박스 테스트 키 사용)
+TOSS_SECRET_KEY=test_sk_pP2YxJ4K87apm2lqMegpVRGZwXLO
+TOSS_CLIENT_KEY=test_ck_pP2YxJ4K87Z9dKKBg9y0rRGZwXLO

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 HELP.md
 .gradle
 build/
+
+### Env ###
+.env
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,9 @@ subprojects {
 
 	tasks.withType(Test) {
 		systemProperty 'spring.profiles.active', 'test'
+		// Toss 키는 yml/git 에 커밋하지 않으므로(.env / --env-file 로 주입),
+		// CI 테스트 컨텍스트 로딩용으로 공개된 Toss 샌드박스 테스트 키를 주입한다.
+		environment 'TOSS_SECRET_KEY', System.getenv().getOrDefault('TOSS_SECRET_KEY', 'test_sk_pP2YxJ4K87apm2lqMegpVRGZwXLO')
+		environment 'TOSS_CLIENT_KEY', System.getenv().getOrDefault('TOSS_CLIENT_KEY', 'test_ck_pP2YxJ4K87Z9dKKBg9y0rRGZwXLO')
 	}
 }

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // .env 로딩 (로컬 실행 시 TOSS_* 등 환경변수 주입). 파일 없으면 무시 → CI/배포 영향 없음
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -75,4 +78,9 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// 로컬 bootRun 이 저장소 루트의 .env 를 읽도록 작업 디렉터리를 루트로 맞춘다
+bootRun {
+    workingDir = rootProject.projectDir
 }

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -35,8 +35,9 @@ payment:
     retry-time: 5
 toss:
   payment:
-    secret-key: test_sk_pP2YxJ4K87apm2lqMegpVRGZwXLO
-    client-key: test_ck_pP2YxJ4K87Z9dKKBg9y0rRGZwXLO
+    # 키는 yml 에 커밋하지 않는다. 로컬은 .env, 배포는 --env-file 로 주입 (.env.example 참고)
+    secret-key: ${TOSS_SECRET_KEY}
+    client-key: ${TOSS_CLIENT_KEY}
     base-url: https://api.tosspayments.com/v1
     connect-timeout: 3000
     read-timeout: 10000


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60 

## 📝작업 내용

> application.yml 에 평문 커밋되어 있던 Toss secret/client 키를 ${TOSS_SECRET_KEY} / ${TOSS_CLIENT_KEY} 참조로 대체.

- .env (gitignore) + .env.example(템플릿) 로 키 관리

### 주요 변경사항

### 의사결정 사항

### 향후 작업
- [ ] TODO

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
