### PR TITLE
refactor : 인가 실패 예외를 BusinessException(403) 패턴으로 통일 (#62)

### DIFF
--- a/module-common/src/main/java/com/whiskey/exception/CommonErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/CommonErrorCode.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CommonErrorCode implements BaseErrorCode {
     // 서버 에러
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."),
+
+    // 인가 실패 (인증은 되었으나 해당 리소스에 접근할 권한이 없음)
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/module-domain/src/main/java/com/whiskey/domain/order/Order.java
+++ b/module-domain/src/main/java/com/whiskey/domain/order/Order.java
@@ -3,6 +3,8 @@ package com.whiskey.domain.order;
 import com.whiskey.domain.base.BaseEntity;
 import com.whiskey.domain.order.enums.OrderStatus;
 import com.whiskey.domain.stock.StockReservation;
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -86,7 +88,7 @@ public class Order extends BaseEntity {
 
     public void validatePayment(Long memberId, BigDecimal totalPrice) {
         if(!this.memberId.equals(memberId)) {
-            throw new IllegalArgumentException("내 주문만 결제할 수 있습니다.");
+            throw new BusinessException(CommonErrorCode.FORBIDDEN, "내 주문만 결제할 수 있습니다.");
         }
 
         if(this.orderStatus != OrderStatus.PENDING) {

--- a/module-domain/src/main/java/com/whiskey/domain/order/service/OrderService.java
+++ b/module-domain/src/main/java/com/whiskey/domain/order/service/OrderService.java
@@ -13,6 +13,8 @@ import com.whiskey.domain.payment.repository.PaymentRepository;
 import com.whiskey.domain.stock.repository.StockRepository;
 import com.whiskey.domain.stock.Stock;
 import com.whiskey.domain.stock.service.StockReservationService;
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
 import com.whiskey.exception.ErrorCode;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -94,7 +96,7 @@ public class OrderService {
         Order order = getOrder(orderId);
 
         if(!order.getMemberId().equals(memberId)) {
-            throw new IllegalArgumentException("본인의 주문만 취소가 가능합니다.");
+            throw new BusinessException(CommonErrorCode.FORBIDDEN, "본인의 주문만 취소가 가능합니다.");
         }
 
         order.cancelReservation();

--- a/module-domain/src/main/java/com/whiskey/domain/payment/service/PaymentService.java
+++ b/module-domain/src/main/java/com/whiskey/domain/payment/service/PaymentService.java
@@ -12,6 +12,8 @@ import com.whiskey.domain.payment.dto.PaymentPrepareCommand;
 import com.whiskey.domain.payment.dto.PaymentPrepareResult;
 import com.whiskey.domain.payment.enums.PaymentStatus;
 import com.whiskey.domain.payment.repository.PaymentRepository;
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
 import com.whiskey.exception.ErrorCode;
 import com.whiskey.payment.client.PaymentClient;
 import com.whiskey.payment.dto.PaymentResponse;
@@ -42,7 +44,7 @@ public class PaymentService {
 
         // 3. 내 주문이 맞는지 확인
         if(!order.getMemberId().equals(member.getId())) {
-            throw new IllegalArgumentException("내 주문만 결제할 수 있습니다.");
+            throw new BusinessException(CommonErrorCode.FORBIDDEN, "내 주문만 결제할 수 있습니다.");
         }
 
         // 4. 주문 상태 확인
@@ -83,7 +85,7 @@ public class PaymentService {
         Payment payment = paymentRepository.findByPaymentOrderId(command.orderId()).orElseThrow(() -> new IllegalStateException("결제 정보를 찾을 수 없습니다"));
 
         if(!payment.getMember().getId().equals(command.memberId())) {
-            throw new IllegalArgumentException("memberId가 다릅니다.");
+            throw new BusinessException(CommonErrorCode.FORBIDDEN, "본인의 결제만 승인할 수 있습니다.");
         }
 
         if(!payment.getAmount().equals(command.amount())) {

--- a/module-domain/src/main/java/com/whiskey/domain/review/service/ReviewService.java
+++ b/module-domain/src/main/java/com/whiskey/domain/review/service/ReviewService.java
@@ -14,6 +14,8 @@ import com.whiskey.domain.review.dto.ReviewInfo;
 import com.whiskey.domain.review.repository.ReviewRepository;
 import com.whiskey.domain.whiskey.Whiskey;
 import com.whiskey.domain.whiskey.service.WhiskeyService;
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
 import com.whiskey.exception.ErrorCode;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -68,7 +70,7 @@ public class ReviewService {
         Review review = checkExistReview(id);
 
         if(!review.getMember().getId().equals(reviewDto.memberId())) {
-            throw ErrorCode.UNAUTHORIZED.exception("본인의 리뷰만 수정가능합니다.");
+            throw new BusinessException(CommonErrorCode.FORBIDDEN, "본인의 리뷰만 수정가능합니다.");
         }
 
         if(!whiskey.getId().equals(reviewDto.whiskeyId())) {
@@ -89,7 +91,7 @@ public class ReviewService {
         Whiskey whiskey = checkExistWhiskey(review.getWhiskey().getId());
 
         if(!review.getMember().getId().equals(memberId)) {
-            throw ErrorCode.UNAUTHORIZED.exception("본인의 리뷰만 삭제가능합니다.");
+            throw new BusinessException(CommonErrorCode.FORBIDDEN, "본인의 리뷰만 삭제가능합니다.");
         }
 
         review.delete();

--- a/module-domain/src/test/java/com/whiskey/domain/order/OrderTest.java
+++ b/module-domain/src/test/java/com/whiskey/domain/order/OrderTest.java
@@ -1,0 +1,41 @@
+package com.whiskey.domain.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class OrderTest {
+
+    private static final BigDecimal PRICE = new BigDecimal("100");
+
+    @Test
+    @DisplayName("본인 주문이 아니면 결제 검증 시 인가 실패(FORBIDDEN, 403)")
+    void validatePayment_다른회원_FORBIDDEN() {
+        Order order = Order.of(1L, PRICE, LocalDateTime.now().plusMinutes(10));
+
+        assertThatThrownBy(() -> order.validatePayment(2L, PRICE))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(ex -> {
+                BusinessException be = (BusinessException) ex;
+                assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.FORBIDDEN);
+                assertThat(be.getErrorCode().getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+            });
+    }
+
+    @Test
+    @DisplayName("본인 주문이면 소유권 검증을 통과한다")
+    void validatePayment_본인_통과() {
+        Order order = Order.of(1L, PRICE, LocalDateTime.now().plusMinutes(10));
+
+        assertThatCode(() -> order.validatePayment(1L, PRICE))
+            .doesNotThrowAnyException();
+    }
+}

--- a/module-domain/src/test/java/com/whiskey/domain/order/service/OrderServiceTest.java
+++ b/module-domain/src/test/java/com/whiskey/domain/order/service/OrderServiceTest.java
@@ -1,0 +1,49 @@
+package com.whiskey.domain.order.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.whiskey.domain.order.Order;
+import com.whiskey.domain.order.repository.OrderRepository;
+import com.whiskey.domain.payment.repository.PaymentRepository;
+import com.whiskey.domain.stock.repository.StockRepository;
+import com.whiskey.domain.stock.service.StockReservationService;
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
+
+class OrderServiceTest {
+
+    private final OrderRepository orderRepository = mock(OrderRepository.class);
+    private final OrderService orderService = new OrderService(
+        orderRepository,
+        mock(StockRepository.class),
+        mock(PaymentRepository.class),
+        mock(StockReservationService.class),
+        mock(OrderExpiryService.class),
+        mock(ApplicationEventPublisher.class)
+    );
+
+    @Test
+    @DisplayName("본인 주문이 아니면 취소 시 인가 실패(FORBIDDEN, 403)")
+    void cancelOrder_다른회원_FORBIDDEN() {
+        Order order = Order.of(1L, new BigDecimal("100"), LocalDateTime.now().plusMinutes(10));
+        when(orderRepository.findById(10L)).thenReturn(Optional.of(order));
+
+        assertThatThrownBy(() -> orderService.cancelOrder(10L, 2L))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(ex -> {
+                BusinessException be = (BusinessException) ex;
+                assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.FORBIDDEN);
+                assertThat(be.getErrorCode().getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+            });
+    }
+}

--- a/module-domain/src/test/java/com/whiskey/domain/payment/service/PaymentServiceTest.java
+++ b/module-domain/src/test/java/com/whiskey/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,49 @@
+package com.whiskey.domain.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.whiskey.domain.member.Member;
+import com.whiskey.domain.member.service.MemberService;
+import com.whiskey.domain.order.service.OrderService;
+import com.whiskey.domain.payment.Payment;
+import com.whiskey.domain.payment.dto.PaymentConfirmCommand;
+import com.whiskey.domain.payment.repository.PaymentRepository;
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class PaymentServiceTest {
+
+    private final PaymentRepository paymentRepository = mock(PaymentRepository.class);
+    private final PaymentService paymentService = new PaymentService(
+        paymentRepository,
+        mock(OrderService.class),
+        mock(MemberService.class)
+    );
+
+    @Test
+    @DisplayName("본인 결제가 아니면 승인 검증 시 인가 실패(FORBIDDEN, 403)")
+    void validatePayment_다른회원_FORBIDDEN() {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(1L);
+        Payment payment = mock(Payment.class);
+        when(payment.getMember()).thenReturn(owner);
+        when(paymentRepository.findByPaymentOrderId("order-1")).thenReturn(Optional.of(payment));
+
+        PaymentConfirmCommand command = new PaymentConfirmCommand(2L, "order-1", 1000L, "pay-key");
+
+        assertThatThrownBy(() -> paymentService.validatePayment(command))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(ex -> {
+                BusinessException be = (BusinessException) ex;
+                assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.FORBIDDEN);
+                assertThat(be.getErrorCode().getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+            });
+    }
+}

--- a/module-domain/src/test/java/com/whiskey/domain/review/service/ReviewServiceTest.java
+++ b/module-domain/src/test/java/com/whiskey/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,76 @@
+package com.whiskey.domain.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.whiskey.domain.member.Member;
+import com.whiskey.domain.member.service.MemberService;
+import com.whiskey.domain.review.Review;
+import com.whiskey.domain.review.dto.ReviewCommand;
+import com.whiskey.domain.review.repository.ReviewRepository;
+import com.whiskey.domain.whiskey.Whiskey;
+import com.whiskey.domain.whiskey.service.WhiskeyService;
+import com.whiskey.exception.BusinessException;
+import com.whiskey.exception.CommonErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
+
+class ReviewServiceTest {
+
+    private final ReviewRepository reviewRepository = mock(ReviewRepository.class);
+    private final WhiskeyService whiskeyService = mock(WhiskeyService.class);
+    private final MemberService memberService = mock(MemberService.class);
+    private final ReviewService reviewService = new ReviewService(
+        reviewRepository, whiskeyService, memberService, mock(ApplicationEventPublisher.class));
+
+    private Review reviewOwnedBy(long ownerId) {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(ownerId);
+        Review review = mock(Review.class);
+        when(review.getMember()).thenReturn(owner);
+        return review;
+    }
+
+    @Test
+    @DisplayName("본인 리뷰가 아니면 수정 시 인가 실패(FORBIDDEN, 403)")
+    void update_다른회원_FORBIDDEN() {
+        Review review = reviewOwnedBy(1L);
+        when(memberService.getMember(anyLong())).thenReturn(mock(Member.class));
+        when(whiskeyService.checkExistWhiskey(anyLong())).thenReturn(mock(Whiskey.class));
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+
+        // 리뷰 소유자(1L)와 다른 회원(2L)이 수정 요청
+        ReviewCommand command = new ReviewCommand(10L, 2L, 5, "content");
+
+        assertThatThrownBy(() -> reviewService.update(1L, command))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(ex -> assertForbidden((BusinessException) ex));
+    }
+
+    @Test
+    @DisplayName("본인 리뷰가 아니면 삭제 시 인가 실패(FORBIDDEN, 403)")
+    void delete_다른회원_FORBIDDEN() {
+        Review review = reviewOwnedBy(1L);
+        Whiskey whiskey = mock(Whiskey.class);
+        when(whiskey.getId()).thenReturn(10L);
+        when(review.getWhiskey()).thenReturn(whiskey);
+        when(reviewRepository.findById(1L)).thenReturn(Optional.of(review));
+        when(whiskeyService.checkExistWhiskey(anyLong())).thenReturn(mock(Whiskey.class));
+
+        // 리뷰 소유자(1L)와 다른 회원(2L)이 삭제 요청
+        assertThatThrownBy(() -> reviewService.delete(1L, 2L))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(ex -> assertForbidden((BusinessException) ex));
+    }
+
+    private void assertForbidden(BusinessException be) {
+        assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.FORBIDDEN);
+        assertThat(be.getErrorCode().getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62 

## 📝작업 내용

인가 실패가 IllegalArgumentException(→500) / ErrorCode.UNAUTHORIZED(401)로 제각각 던져지던 것을 CommonErrorCode.FORBIDDEN(403)으로 통일한다.

도메인별 세부 ErrorCode 매핑 및 deprecated ErrorCode 제거는 후속 이슈로 분리.

### 주요 변경사항

### 의사결정 사항

### 향후 작업
- [ ] TODO

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
