### PR TITLE
fix : 재고 예약 동시성 재시도가 실제 동작하도록 @Retryable 트랜잭션 경계 이동 (#64)

### DIFF
--- a/module-api/src/test/java/com/whiskey/integration/order/OrderCreateConcurrencyTest.java
+++ b/module-api/src/test/java/com/whiskey/integration/order/OrderCreateConcurrencyTest.java
@@ -1,0 +1,120 @@
+
+
+package com.whiskey.integration.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.whiskey.domain.order.dto.OrderCommand;
+import com.whiskey.domain.order.dto.OrderCommand.OrderItem;
+import com.whiskey.domain.order.service.OrderService;
+import com.whiskey.domain.stock.Stock;
+import com.whiskey.domain.stock.repository.StockRepository;
+import com.whiskey.domain.whiskey.Whiskey;
+import com.whiskey.domain.whiskey.enums.MaltType;
+import com.whiskey.domain.whiskey.repository.WhiskeyRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * 이슈 #64 검증 테스트.
+ *
+ * <p>동일 재고(핫 스톡)에 동시 주문이 몰릴 때, {@code OrderService.createOrder}에 건
+ * {@code @Retryable}이 실제로 동작하여 재고 정합성이 유지되는지 검증한다.</p>
+ *
+ * <p>이 스키마에서 동시성 충돌은 낙관락 버전 불일치
+ * ({@code ObjectOptimisticLockingFailureException})뿐 아니라, {@code stock_reservation}이
+ * {@code stocks}를 FK 참조하며 INSERT(공유락)+UPDATE(배타락)가 겹쳐 발생하는
+ * InnoDB 데드락/락 대기({@code CannotAcquireLockException})로도 표면화된다.
+ * 재시도는 두 경우의 공통 상위인 {@code ConcurrencyFailureException}을 대상으로 한다.</p>
+ *
+ * <p>재시도가 없던 기존 코드에서는 충돌한 주문이 그대로 실패해
+ * {@code failures}가 비지 않고 최종 재고도 0이 되지 않는다. 재시도가 동작하면
+ * 두 주문 모두 성공하고 재고는 정확히 0이 된다.</p>
+ *
+ * <p>동시 스레드 수는 2로 둔다. 충돌이 나면 패한 트랜잭션 하나만 재시도되고,
+ * 그 시점엔 경쟁자가 이미 커밋을 마쳤으므로 재시도 1회로 반드시 성공한다
+ * → {@code maxAttempts=3} 한도 안에서 결정적으로 재시도 동작을 증명한다.
+ * (3 이상의 고경합 N-way 파일업 해소는 이 테스트의 범위가 아니며, 지터/분산락(#65) 영역)</p>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class OrderCreateConcurrencyTest {
+
+    private static final int CONCURRENCY = 2;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private WhiskeyRepository whiskeyRepository;
+
+    @Test
+    @DisplayName("동일 재고에 동시 주문이 몰려도 낙관락 재시도로 재고 정합성이 유지된다")
+    void 동시주문_낙관락재시도_재고정합성_유지() throws InterruptedException {
+        // given : 재고 CONCURRENCY개짜리 핫 스톡 1건
+        Whiskey whiskey = whiskeyRepository.save(Whiskey.builder()
+            .distillery("Test Distillery")
+            .name("Concurrency Test Whiskey")
+            .country("Scotland")
+            .age(12)
+            .volume(700)
+            .maltType(MaltType.SINGLE_MALT)
+            .abv(40.0)
+            .description("issue #64 concurrency verification")
+            .build());
+
+        Stock stock = stockRepository.save(
+            Stock.of(whiskey.getId(), CONCURRENCY, new BigDecimal("50000")));
+        Long stockId = stock.getId();
+
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENCY);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch doneGate = new CountDownLatch(CONCURRENCY);
+        AtomicInteger successCount = new AtomicInteger();
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        // when : 동일 stockId에 각 1개씩 동시 주문
+        for (int i = 0; i < CONCURRENCY; i++) {
+            long memberId = i + 1L;
+            executor.submit(() -> {
+                try {
+                    startGate.await();
+                    OrderCommand command = new OrderCommand(memberId,
+                        List.of(new OrderItem(stockId, 1)));
+                    orderService.createOrder(command);
+                    successCount.incrementAndGet();
+                } catch (Throwable t) {
+                    failures.add(t);
+                } finally {
+                    doneGate.countDown();
+                }
+            });
+        }
+
+        startGate.countDown();                      // 동시에 출발
+        boolean finished = doneGate.await(30, TimeUnit.SECONDS);
+        executor.shutdownNow();
+
+        // then : 전부 성공하고, 재고는 정확히 0 (lost update 없음)
+        assertThat(finished).as("모든 주문 스레드가 30초 내 종료").isTrue();
+        assertThat(failures).as("낙관락 재시도로 실패 없이 처리되어야 함").isEmpty();
+        assertThat(successCount.get()).isEqualTo(CONCURRENCY);
+
+        Stock reloaded = stockRepository.findById(stockId).orElseThrow();
+        assertThat(reloaded.getAvailableQuantity()).isZero();
+    }
+}

--- a/module-common/src/main/java/com/whiskey/exception/OrderErrorCode.java
+++ b/module-common/src/main/java/com/whiskey/exception/OrderErrorCode.java
@@ -8,7 +8,8 @@ public enum OrderErrorCode implements BaseErrorCode {
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
     INVALID_ORDER_ITEM(HttpStatus.BAD_REQUEST, "재고가 없는 상품이 포함되어 있습니다."),
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
-    ORDER_ALREADY_CANCELLED(HttpStatus.CONFLICT, "이미 취소된 주문입니다.");
+    ORDER_ALREADY_CANCELLED(HttpStatus.CONFLICT, "이미 취소된 주문입니다."),
+    STOCK_RESERVATION_CONFLICT(HttpStatus.CONFLICT, "주문이 몰려 재고 예약에 실패했습니다. 잠시 후 다시 시도해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/module-domain/src/main/java/com/whiskey/domain/order/service/OrderService.java
+++ b/module-domain/src/main/java/com/whiskey/domain/order/service/OrderService.java
@@ -23,6 +23,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +47,16 @@ public class OrderService {
     @Value("${order.reservation.expire-time:30}")
     private int expireTime;
 
+    // 동일 재고에 동시 주문이 몰리면 낙관락 버전 충돌(ObjectOptimisticLockingFailureException) 또는
+    // InnoDB 데드락/락 대기(CannotAcquireLockException)로 표면화된다.
+    // 두 경우의 공통 상위인 ConcurrencyFailureException을 재시도 대상으로 잡아, 새 트랜잭션에서 전체를 원자적으로 재실행한다.
+    // random 지터로 재시도가 같은 시점에 몰려 다시 충돌하는 lockstep을 완화한다.
+    // (고경합 상황의 근본 해법은 별도 이슈 #65의 분산락 검토 대상)
+    @Retryable(
+        retryFor = ConcurrencyFailureException.class,
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 100, multiplier = 2, random = true)
+    )
     @Transactional
     public OrderResult createOrder(OrderCommand command) {
         // 주문 생성 및 재고 예약
@@ -73,6 +87,13 @@ public class OrderService {
         // 주문 만료시간 이벤트 발행
         eventPublisher.publishEvent(new OrderExpiryRegisteredEvent(order.getId(), expireAt));
         return new OrderResult(order.getId());
+    }
+
+    // 재시도(3회)를 모두 소진한 경우: 고경합으로 재고 예약 실패 → 409 응답
+    @Recover
+    public OrderResult recoverCreateOrder(ConcurrencyFailureException e, OrderCommand command) {
+        log.warn("재고 예약 동시성 충돌 재시도 소진 - memberId: {}, cause: {}", command.memberId(), e.getClass().getSimpleName());
+        throw OrderErrorCode.STOCK_RESERVATION_CONFLICT.exception();
     }
 
     private BigDecimal calculateTotalPrice(List<OrderItem> items, List<Stock> stocks) {

--- a/module-domain/src/main/java/com/whiskey/domain/stock/service/StockReservationService.java
+++ b/module-domain/src/main/java/com/whiskey/domain/stock/service/StockReservationService.java
@@ -4,11 +4,8 @@ import com.whiskey.domain.order.Order;
 import com.whiskey.domain.stock.Stock;
 import com.whiskey.domain.stock.StockReservation;
 import com.whiskey.domain.stock.repository.StockRepository;
-import jakarta.persistence.OptimisticLockException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,11 +14,8 @@ public class StockReservationService {
 
     private final StockRepository stockRepository;
 
-    @Retryable(
-        value = OptimisticLockException.class,
-        maxAttempts = 3,
-        backoff = @Backoff(delay = 100, multiplier = 2)
-    )
+    // 낙관락 충돌 재시도는 트랜잭션 경계(OrderService.createOrder)에서 처리한다.
+    // 이 메서드는 바깥 트랜잭션에 합류하며, 버전 충돌은 커밋(flush) 시점에 발생한다.
     public void reserveStock(Order order, Stock stock, int quantity, LocalDateTime expireAt) {
         Stock freshStock = stockRepository.findById(stock.getId())
             .orElseThrow(() -> new IllegalArgumentException("재고를 찾을 수 없습니다."));

--- a/module-domain/src/test/java/com/whiskey/domain/order/service/OrderServiceTest.java
+++ b/module-domain/src/test/java/com/whiskey/domain/order/service/OrderServiceTest.java
@@ -6,18 +6,23 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.whiskey.domain.order.Order;
+import com.whiskey.domain.order.dto.OrderCommand;
+import com.whiskey.domain.order.dto.OrderCommand.OrderItem;
 import com.whiskey.domain.order.repository.OrderRepository;
 import com.whiskey.domain.payment.repository.PaymentRepository;
 import com.whiskey.domain.stock.repository.StockRepository;
 import com.whiskey.domain.stock.service.StockReservationService;
 import com.whiskey.exception.BusinessException;
 import com.whiskey.exception.CommonErrorCode;
+import com.whiskey.exception.OrderErrorCode;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.http.HttpStatus;
 
 class OrderServiceTest {
@@ -44,6 +49,21 @@ class OrderServiceTest {
                 BusinessException be = (BusinessException) ex;
                 assertThat(be.getErrorCode()).isEqualTo(CommonErrorCode.FORBIDDEN);
                 assertThat(be.getErrorCode().getHttpStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+            });
+    }
+
+    @Test
+    @DisplayName("동시성 충돌 재시도 소진 시 recover가 409(STOCK_RESERVATION_CONFLICT)로 변환한다")
+    void createOrder_재시도소진_recover_409() {
+        OrderCommand command = new OrderCommand(1L, List.of(new OrderItem(10L, 1)));
+
+        assertThatThrownBy(() ->
+            orderService.recoverCreateOrder(new ConcurrencyFailureException("simulated conflict"), command))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(ex -> {
+                BusinessException be = (BusinessException) ex;
+                assertThat(be.getErrorCode()).isEqualTo(OrderErrorCode.STOCK_RESERVATION_CONFLICT);
+                assertThat(be.getErrorCode().getHttpStatus()).isEqualTo(HttpStatus.CONFLICT);
             });
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #64 

## 📝작업 내용

- StockReservationService.reserveStock의 @Retryable은 바깥 트랜잭션에 합류해 커밋(flush) 시점 충돌을 잡지 못하는 dead 애노테이션이라 ㅈ거
- 재시도 경계를 OrderService.createOrder(@Transactional)로 이동해 retry가 트랜잭션을 감싸도록 하여 매 재시도마다 새 트랜잭션에서 원자적 재실행 보장

### 주요 변경사항

### 의사결정 사항

### 향후 작업
- [ ] TODO

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
